### PR TITLE
Potential fix for code scanning alert no. 3: Uncontrolled data used in path expression

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -44,10 +44,10 @@ app.get("/files", (req, res) => {
 // Actualizar datos EXIF de un archivo
 app.post("/update-exif", async (req, res) => {
   const { fileName, exifData } = req.body;
-  const filePath = path.join(rootDir, fileName);
+  const filePath = path.resolve(rootDir, fileName);
 
-  if (!fs.existsSync(filePath)) {
-    return res.status(404).send("File not found.");
+  if (!filePath.startsWith(rootDir) || !fs.existsSync(filePath)) {
+    return res.status(404).send("File not found or invalid path.");
   }
 
   try {


### PR DESCRIPTION
Potential fix for [https://github.com/Jaumoso/web-exif/security/code-scanning/3](https://github.com/Jaumoso/web-exif/security/code-scanning/3)

To fix the problem, we need to ensure that the constructed file path is contained within a safe root folder. We will normalize the path using `path.resolve` to remove any `..` segments and then check that the normalized path starts with the root folder. This will prevent path traversal attacks.

1. Normalize the `filePath` using `path.resolve`.
2. Check that the normalized `filePath` starts with `rootDir`.
3. If the check fails, return an error response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
